### PR TITLE
Guardar configuración en localStorage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,7 +37,7 @@ h1 {
   margin-top: 0px;
 }
 .container {
-  width: 100%;
+  width: 100vw;
   min-height: 100vh;
   background: #fff;
   padding: 2rem;


### PR DESCRIPTION
## Summary
- store selected subject and topic amounts in `localStorage`
- add topic information when selecting questions
- display topic during quiz and in results
- make page use entire window width

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68704752fafc833288bae7672507f178